### PR TITLE
fix: force matplotlib Agg backend to avoid Tk thread crash in climatology

### DIFF
--- a/climate_tookit/climatology/long_term_climatology.py
+++ b/climate_tookit/climatology/long_term_climatology.py
@@ -68,6 +68,12 @@ from utils.models import ClimateVariable
 PREPROCESS_AVAILABLE = True
 
 try:
+    import matplotlib
+    # Force the non-interactive Agg backend: plots are only saved to PNG, never
+    # shown. This avoids the Tk/Tcl backend, which crashes ("main thread is not
+    # in main loop" / "Tcl_AsyncDelete") when figures are created while worker
+    # threads are alive during the parallel ensemble fetch.
+    matplotlib.use('Agg')
     import matplotlib.pyplot as plt
     from matplotlib.ticker import MaxNLocator
     MATPLOTLIB_AVAILABLE = True


### PR DESCRIPTION
﻿## Summary
Follow-up to the climatology parallelization (#113). After running the 16 models concurrently, generating the ensemble plots with matplotlib's default interactive **Tk** backend crashed at interpreter shutdown:

```
RuntimeError: main thread is not in main loop
Tcl_AsyncDelete: async handler deleted by the wrong thread
```

The `Tcl_AsyncDelete` abort is fatal and **truncated the printed climatology report** (the multi-scenario report prints after all fetches finish, so the crash cut it off).

## Fix
Force the non-interactive **Agg** backend at import time. Plots are only saved to PNG, never displayed, so Agg is the correct backend and it removes Tk entirely.

```python
import matplotlib
matplotlib.use('Agg')
import matplotlib.pyplot as plt
```

## Verified
Full command (2 scenarios × 16 models × 30 years, `--workers 8`): completes in ~76s, **zero Tcl/Tk errors**, and the full report including the cross-scenario summary now prints.
