### PR TITLE
feat: classify NTx35/NTx40 heat-stress days in hazard assessment

### DIFF
--- a/climate_tookit/calculate_hazards/ensemble_hazards.py
+++ b/climate_tookit/calculate_hazards/ensemble_hazards.py
@@ -31,6 +31,7 @@ from hazards import (
     calculate_season_statistics,
     add_et0,
     water_balance_hazards,
+    heat_stress_hazards,
     _severity_symbol,
     DEFAULT_SOILCP,
     DEFAULT_SOILSAT,
@@ -213,6 +214,8 @@ def _evaluate(crop: str, lat: float, lon: float,
                                   'status':  evaluate_threshold(v, th['TAVG'])}
     # NDWS / NDWL0 water-balance severity (Adaptation Atlas classes)
     hazards.update(water_balance_hazards(stats))
+    # NTx35 / NTx40 heat-stress severity
+    hazards.update(heat_stress_hazards(stats))
     length = (datetime.fromisoformat(w['end'])
               - datetime.fromisoformat(w['start'])).days
     return {
@@ -281,6 +284,8 @@ def _avg_hazards(crop: str, agg: Dict) -> Dict:
                               'status': evaluate_threshold(v, th['TAVG'])}
     # NDWS / NDWL0 severity on the ensemble-mean day counts
     out.update(water_balance_hazards(agg))
+    # NTx35 / NTx40 heat-stress severity on the ensemble-mean day counts
+    out.update(heat_stress_hazards(agg))
     return out
 
 def _agg_hazard_statuses(bucket: List[Dict]) -> Dict:
@@ -289,7 +294,8 @@ def _agg_hazard_statuses(bucket: List[Dict]) -> Dict:
     Returns the modal status for each hazard indicator plus a counts breakdown.
     """
     from collections import Counter
-    indicators = ['precipitation', 'temperature', 'water_stress', 'water_logging']
+    indicators = ['precipitation', 'temperature', 'water_stress', 'water_logging',
+                  'heat_stress', 'extreme_heat_stress']
     out = {}
     for ind in indicators:
         statuses = [
@@ -618,6 +624,14 @@ def _print_block(a: Dict, crop: str, lat: float, lon: float,
         wl = h['water_logging']
         print(f"  {'Water Logging (NDWL0)':<25} {s.get('NDWL0', 0):>16.2f} d   "
               f"[{_severity_symbol(wl['status'])}] {wl['status'].replace('_', ' ').upper()}")
+    if 'heat_stress' in h:
+        hs = h['heat_stress']
+        print(f"  {'Heat Stress (NTx35)':<25} {s.get('NTx35', 0):>16.2f} d   "
+              f"[{_severity_symbol(hs['status'])}] {hs['status'].replace('_', ' ').upper()}")
+    if 'extreme_heat_stress' in h:
+        ehs = h['extreme_heat_stress']
+        print(f"  {'Extreme Heat (NTx40)':<25} {s.get('NTx40', 0):>16.2f} d   "
+              f"[{_severity_symbol(ehs['status'])}] {ehs['status'].replace('_', ' ').upper()}")
     print(f"\n{'='*70}")
 
 def print_results(r: Dict) -> None:
@@ -679,6 +693,12 @@ def print_results(r: Dict) -> None:
     if 'water_logging' in h:
         print(f"  NDWL0  status:        [{_severity_symbol(h['water_logging']['status'])}] "
               f"{h['water_logging']['status'].replace('_', ' ').upper()}")
+    if 'heat_stress' in h:
+        print(f"  NTx35  status:        [{_severity_symbol(h['heat_stress']['status'])}] "
+              f"{h['heat_stress']['status'].replace('_', ' ').upper()}")
+    if 'extreme_heat_stress' in h:
+        print(f"  NTx40  status:        [{_severity_symbol(h['extreme_heat_stress']['status'])}] "
+              f"{h['extreme_heat_stress']['status'].replace('_', ' ').upper()}")
     print(f"\n{'='*70}\n")
 
 # CLI

--- a/climate_tookit/calculate_hazards/ensemble_hazards.py
+++ b/climate_tookit/calculate_hazards/ensemble_hazards.py
@@ -214,8 +214,8 @@ def _evaluate(crop: str, lat: float, lon: float,
                                   'status':  evaluate_threshold(v, th['TAVG'])}
     # NDWS / NDWL0 water-balance severity (Adaptation Atlas classes)
     hazards.update(water_balance_hazards(stats))
-    # NTx35 / NTx40 heat-stress severity
-    hazards.update(heat_stress_hazards(stats))
+    # NTx35 / NTx40 heat-stress severity (crop-specific bands)
+    hazards.update(heat_stress_hazards(stats, crop))
     length = (datetime.fromisoformat(w['end'])
               - datetime.fromisoformat(w['start'])).days
     return {
@@ -285,7 +285,7 @@ def _avg_hazards(crop: str, agg: Dict) -> Dict:
     # NDWS / NDWL0 severity on the ensemble-mean day counts
     out.update(water_balance_hazards(agg))
     # NTx35 / NTx40 heat-stress severity on the ensemble-mean day counts
-    out.update(heat_stress_hazards(agg))
+    out.update(heat_stress_hazards(agg, crop))
     return out
 
 def _agg_hazard_statuses(bucket: List[Dict]) -> Dict:

--- a/climate_tookit/calculate_hazards/hazards.py
+++ b/climate_tookit/calculate_hazards/hazards.py
@@ -315,28 +315,51 @@ def water_balance_hazards(stats: Dict[str, Any]) -> Dict[str, Any]:
         }
     return out
 
-# Heat-stress severity classes (unit: days per season), tunable defaults.
-# NTx35 = days Tmax > 35C, NTx40 = days Tmax > 40C. Bands give (moderate,
-# severe, extreme) floors; values below the moderate floor are no_significant_stress.
-NTX35_SEVERITY = (5, 15, 30)
-NTX40_SEVERITY = (1, 5, 10)
+# Heat-stress severity classes (unit: days per season), per the AE-project
+# crop-specific hazard thresholds wiki. Bands give (moderate, severe, extreme)
+# floors; values below the moderate floor are no_significant_stress.
+# NTx35 = days Tmax > 35C, NTx40 = days Tmax > 40C.
+NTX35_SEVERITY_DEFAULT = (7, 14, 21)
+NTX40_SEVERITY_DEFAULT = (7, 14, 21)
 
-def heat_stress_hazards(stats: Dict[str, Any]) -> Dict[str, Any]:
-    """Build NTx35 / NTx40 heat-stress severity entries from season statistics."""
+# Crop-specific overrides (only the crops that deviate from the default).
+NTX35_SEVERITY_BY_CROP: Dict[str, Tuple[int, int, int]] = {
+    'Cassava': (1, 5, 10),
+}
+NTX40_SEVERITY_BY_CROP: Dict[str, Tuple[int, int, int]] = {
+    'Millet':       (1, 5, 10),   # Pearl-millet
+    'Sorghum':      (1, 5, 10),
+    'Wheat':        (1, 5, 10),
+    'Cowpea':       (1, 5, 10),
+    'Pigeon peas':  (1, 5, 10),
+    'Sweet potato': (1, 5, 10),
+    'Sesame seeds': (1, 5, 10),
+    'Yams':         (1, 5, 10),   # wiki bands overlap; normalised to 1/5/10
+}
+
+def heat_stress_hazards(stats: Dict[str, Any], crop: Optional[str] = None) -> Dict[str, Any]:
+    """Build NTx35 / NTx40 heat-stress severity entries from season statistics.
+
+    Severity bands are crop-specific; the crop name selects the bands and falls
+    back to the generic defaults when the crop has no override.
+    """
+    crop_key = crop.capitalize() if crop else None
+    ntx35_bounds = NTX35_SEVERITY_BY_CROP.get(crop_key, NTX35_SEVERITY_DEFAULT)
+    ntx40_bounds = NTX40_SEVERITY_BY_CROP.get(crop_key, NTX40_SEVERITY_DEFAULT)
     out: Dict[str, Any] = {}
     if stats.get('NTx35') is not None:
         v = stats['NTx35']
         out['heat_stress'] = {
             'index':      'NTx35',
             'value_days': round(float(v), 2),
-            'status':     classify_water_hazard(v, NTX35_SEVERITY),
+            'status':     classify_water_hazard(v, ntx35_bounds),
         }
     if stats.get('NTx40') is not None:
         v = stats['NTx40']
         out['extreme_heat_stress'] = {
             'index':      'NTx40',
             'value_days': round(float(v), 2),
-            'status':     classify_water_hazard(v, NTX40_SEVERITY),
+            'status':     classify_water_hazard(v, ntx40_bounds),
         }
     return out
 

--- a/climate_tookit/calculate_hazards/hazards.py
+++ b/climate_tookit/calculate_hazards/hazards.py
@@ -315,6 +315,31 @@ def water_balance_hazards(stats: Dict[str, Any]) -> Dict[str, Any]:
         }
     return out
 
+# Heat-stress severity classes (unit: days per season), tunable defaults.
+# NTx35 = days Tmax > 35C, NTx40 = days Tmax > 40C. Bands give (moderate,
+# severe, extreme) floors; values below the moderate floor are no_significant_stress.
+NTX35_SEVERITY = (5, 15, 30)
+NTX40_SEVERITY = (1, 5, 10)
+
+def heat_stress_hazards(stats: Dict[str, Any]) -> Dict[str, Any]:
+    """Build NTx35 / NTx40 heat-stress severity entries from season statistics."""
+    out: Dict[str, Any] = {}
+    if stats.get('NTx35') is not None:
+        v = stats['NTx35']
+        out['heat_stress'] = {
+            'index':      'NTx35',
+            'value_days': round(float(v), 2),
+            'status':     classify_water_hazard(v, NTX35_SEVERITY),
+        }
+    if stats.get('NTx40') is not None:
+        v = stats['NTx40']
+        out['extreme_heat_stress'] = {
+            'index':      'NTx40',
+            'value_days': round(float(v), 2),
+            'status':     classify_water_hazard(v, NTX40_SEVERITY),
+        }
+    return out
+
 def _severity_symbol(status: str) -> str:
     """Console marker for a hazard status (handles severe/extreme classes too)."""
     if 'no_stress' in status or 'no_significant' in status:


### PR DESCRIPTION
﻿## Summary
NTx35 (days Tmax > 35°C) and NTx40 (days Tmax > 40°C) were computed and shown as raw counts in "Hazard Index Counts" but were never assigned a severity status, so they never appeared in the "Hazard Assessment" table — only Precipitation, Temperature (TAVG), NDWS, and NDWL0 were classified.

## Fix
- Add `heat_stress_hazards()` in `hazards.py`, mirroring `water_balance_hazards()`. It classifies the day counts into `no_significant_stress / moderate_stress / severe_stress / extreme_stress` using tunable floors:
  - **NTx35:** 5 / 15 / 30 days (moderate / severe / extreme)
  - **NTx40:** 1 / 5 / 10 days
- Wire it into `ensemble_hazards.py`: per-projection `_evaluate`, the ensemble-mean `_avg_hazards`, the majority-vote `_agg_hazard_statuses` indicator list, and both the per-assessment and overall-ensemble printouts.

## Result
The Hazard Assessment table now includes, e.g.:
```
Heat Stress (NTx35)    6.50 d   [!!] MODERATE STRESS
Extreme Heat (NTx40)   0.00 d   [OK] NO SIGNIFICANT STRESS
```

## Notes
- The severity bands are generic (crop-independent) defaults, defined as `NTX35_SEVERITY` / `NTX40_SEVERITY` constants in `hazards.py` so they are easy to tune or later make crop-specific.
- No change to fetch behavior or performance.
