### PR TITLE
Release: crop-specific NTx35/NTx40 heat-stress classification (#118)

### DIFF
--- a/climate_tookit/calculate_hazards/ensemble_hazards.py
+++ b/climate_tookit/calculate_hazards/ensemble_hazards.py
@@ -31,6 +31,7 @@ from hazards import (
     calculate_season_statistics,
     add_et0,
     water_balance_hazards,
+    heat_stress_hazards,
     _severity_symbol,
     DEFAULT_SOILCP,
     DEFAULT_SOILSAT,
@@ -213,6 +214,8 @@ def _evaluate(crop: str, lat: float, lon: float,
                                   'status':  evaluate_threshold(v, th['TAVG'])}
     # NDWS / NDWL0 water-balance severity (Adaptation Atlas classes)
     hazards.update(water_balance_hazards(stats))
+    # NTx35 / NTx40 heat-stress severity (crop-specific bands)
+    hazards.update(heat_stress_hazards(stats, crop))
     length = (datetime.fromisoformat(w['end'])
               - datetime.fromisoformat(w['start'])).days
     return {
@@ -281,6 +284,8 @@ def _avg_hazards(crop: str, agg: Dict) -> Dict:
                               'status': evaluate_threshold(v, th['TAVG'])}
     # NDWS / NDWL0 severity on the ensemble-mean day counts
     out.update(water_balance_hazards(agg))
+    # NTx35 / NTx40 heat-stress severity on the ensemble-mean day counts
+    out.update(heat_stress_hazards(agg, crop))
     return out
 
 def _agg_hazard_statuses(bucket: List[Dict]) -> Dict:
@@ -289,7 +294,8 @@ def _agg_hazard_statuses(bucket: List[Dict]) -> Dict:
     Returns the modal status for each hazard indicator plus a counts breakdown.
     """
     from collections import Counter
-    indicators = ['precipitation', 'temperature', 'water_stress', 'water_logging']
+    indicators = ['precipitation', 'temperature', 'water_stress', 'water_logging',
+                  'heat_stress', 'extreme_heat_stress']
     out = {}
     for ind in indicators:
         statuses = [
@@ -618,6 +624,14 @@ def _print_block(a: Dict, crop: str, lat: float, lon: float,
         wl = h['water_logging']
         print(f"  {'Water Logging (NDWL0)':<25} {s.get('NDWL0', 0):>16.2f} d   "
               f"[{_severity_symbol(wl['status'])}] {wl['status'].replace('_', ' ').upper()}")
+    if 'heat_stress' in h:
+        hs = h['heat_stress']
+        print(f"  {'Heat Stress (NTx35)':<25} {s.get('NTx35', 0):>16.2f} d   "
+              f"[{_severity_symbol(hs['status'])}] {hs['status'].replace('_', ' ').upper()}")
+    if 'extreme_heat_stress' in h:
+        ehs = h['extreme_heat_stress']
+        print(f"  {'Extreme Heat (NTx40)':<25} {s.get('NTx40', 0):>16.2f} d   "
+              f"[{_severity_symbol(ehs['status'])}] {ehs['status'].replace('_', ' ').upper()}")
     print(f"\n{'='*70}")
 
 def print_results(r: Dict) -> None:
@@ -679,6 +693,12 @@ def print_results(r: Dict) -> None:
     if 'water_logging' in h:
         print(f"  NDWL0  status:        [{_severity_symbol(h['water_logging']['status'])}] "
               f"{h['water_logging']['status'].replace('_', ' ').upper()}")
+    if 'heat_stress' in h:
+        print(f"  NTx35  status:        [{_severity_symbol(h['heat_stress']['status'])}] "
+              f"{h['heat_stress']['status'].replace('_', ' ').upper()}")
+    if 'extreme_heat_stress' in h:
+        print(f"  NTx40  status:        [{_severity_symbol(h['extreme_heat_stress']['status'])}] "
+              f"{h['extreme_heat_stress']['status'].replace('_', ' ').upper()}")
     print(f"\n{'='*70}\n")
 
 # CLI

--- a/climate_tookit/calculate_hazards/hazards.py
+++ b/climate_tookit/calculate_hazards/hazards.py
@@ -315,6 +315,54 @@ def water_balance_hazards(stats: Dict[str, Any]) -> Dict[str, Any]:
         }
     return out
 
+# Heat-stress severity classes (unit: days per season), per the AE-project
+# crop-specific hazard thresholds wiki. Bands give (moderate, severe, extreme)
+# floors; values below the moderate floor are no_significant_stress.
+# NTx35 = days Tmax > 35C, NTx40 = days Tmax > 40C.
+NTX35_SEVERITY_DEFAULT = (7, 14, 21)
+NTX40_SEVERITY_DEFAULT = (7, 14, 21)
+
+# Crop-specific overrides (only the crops that deviate from the default).
+NTX35_SEVERITY_BY_CROP: Dict[str, Tuple[int, int, int]] = {
+    'Cassava': (1, 5, 10),
+}
+NTX40_SEVERITY_BY_CROP: Dict[str, Tuple[int, int, int]] = {
+    'Millet':       (1, 5, 10),   # Pearl-millet
+    'Sorghum':      (1, 5, 10),
+    'Wheat':        (1, 5, 10),
+    'Cowpea':       (1, 5, 10),
+    'Pigeon peas':  (1, 5, 10),
+    'Sweet potato': (1, 5, 10),
+    'Sesame seeds': (1, 5, 10),
+    'Yams':         (1, 5, 10),   # wiki bands overlap; normalised to 1/5/10
+}
+
+def heat_stress_hazards(stats: Dict[str, Any], crop: Optional[str] = None) -> Dict[str, Any]:
+    """Build NTx35 / NTx40 heat-stress severity entries from season statistics.
+
+    Severity bands are crop-specific; the crop name selects the bands and falls
+    back to the generic defaults when the crop has no override.
+    """
+    crop_key = crop.capitalize() if crop else None
+    ntx35_bounds = NTX35_SEVERITY_BY_CROP.get(crop_key, NTX35_SEVERITY_DEFAULT)
+    ntx40_bounds = NTX40_SEVERITY_BY_CROP.get(crop_key, NTX40_SEVERITY_DEFAULT)
+    out: Dict[str, Any] = {}
+    if stats.get('NTx35') is not None:
+        v = stats['NTx35']
+        out['heat_stress'] = {
+            'index':      'NTx35',
+            'value_days': round(float(v), 2),
+            'status':     classify_water_hazard(v, ntx35_bounds),
+        }
+    if stats.get('NTx40') is not None:
+        v = stats['NTx40']
+        out['extreme_heat_stress'] = {
+            'index':      'NTx40',
+            'value_days': round(float(v), 2),
+            'status':     classify_water_hazard(v, ntx40_bounds),
+        }
+    return out
+
 def _severity_symbol(status: str) -> str:
     """Console marker for a hazard status (handles severe/extreme classes too)."""
     if 'no_stress' in status or 'no_significant' in status:


### PR DESCRIPTION
﻿## Summary
Promotes the heat-stress classification (#118) from `staging` to `main`.

NTx35 / NTx40 heat-stress day counts now get a crop-specific severity status (no_significant / moderate / severe / extreme) in the Hazard Assessment table, using the bands from the AE-project crop-specific hazard thresholds wiki:
- NTx35 default (7/14/21); Cassava (1/5/10).
- NTx40 default (7/14/21); Millet, Sorghum, Wheat, Cowpea, Pigeon peas, Sweet potato, Sesame, Yams (1/5/10).

Verified band selection across millet/maize/cassava; parallel/perf behavior unchanged.
