### PR TITLE
Release: NEX-GDDP historical split + compare_datasets parallelization (#72)

### DIFF
--- a/climate_tookit/compare_datasets/compare_datasets.py
+++ b/climate_tookit/compare_datasets/compare_datasets.py
@@ -523,19 +523,33 @@ def compare_sources(sources, lat=None, lon=None, start=None, end=None,
                 else:
                     print(f"  ℹ️   NEX-GDDP ensemble  models={', '.join(models)}  "
                           f"scenario={scenario_key}")
-                    per_model = {}
-                    for m in models:
-                        print(f"        • fetching {m} …")
+                    # Each model is an independent, I/O-bound GEE fetch — run
+                    # them concurrently (capped at 10 to match the GEE
+                    # connection pool), then restore input-model order.
+                    from concurrent.futures import ThreadPoolExecutor, as_completed
+
+                    def _fetch_model(m):
                         try:
                             mdf = _fetch_source(source, lat, lon, start, end,
                                                 model=m, scenario=scenario_key)
+                            return m, mdf, None
                         except Exception as exc:
-                            print(f"        ⚠️   {m} failed: {exc}")
-                            continue
-                        if mdf is not None and not mdf.empty and len(mdf.columns) > 1:
-                            per_model[m] = mdf
-                        else:
-                            print(f"        ⚠️   {m}: no usable variables returned.")
+                            return m, None, str(exc)
+
+                    raw_models = {}
+                    workers = max(1, min(len(models), 10))
+                    with ThreadPoolExecutor(max_workers=workers) as ex:
+                        futs = {ex.submit(_fetch_model, m): m for m in models}
+                        for fut in as_completed(futs):
+                            m, mdf, err = fut.result()
+                            if err is not None:
+                                print(f"        ⚠️   {m} failed: {err}")
+                            elif mdf is not None and not mdf.empty and len(mdf.columns) > 1:
+                                raw_models[m] = mdf
+                                print(f"        • fetched {m}")
+                            else:
+                                print(f"        ⚠️   {m}: no usable variables returned.")
+                    per_model = {m: raw_models[m] for m in models if m in raw_models}
                     if not per_model:
                         print("  ⚠️   nex_gddp ensemble: no models returned usable data.")
                         continue
@@ -647,6 +661,14 @@ def print_report(results: dict, output_dir: str = "./outputs"):
 
 # CLI
 def main():
+    # Ensure Unicode output (emoji status markers, arrows) works on Windows
+    # consoles that default to cp1252.
+    try:
+        sys.stdout.reconfigure(encoding='utf-8')
+        sys.stderr.reconfigure(encoding='utf-8')
+    except (AttributeError, ValueError):
+        pass
+
     parser = argparse.ArgumentParser(
         description="Extended climate dataset comparison tool",
         formatter_class=argparse.RawTextHelpFormatter,

--- a/climate_tookit/fetch_data/source_data/sources/nex_gddp.py
+++ b/climate_tookit/fetch_data/source_data/sources/nex_gddp.py
@@ -55,6 +55,13 @@ NEX_GDDP_SCALE_M = 27830
 
 NEX_GDDP_CHUNK_DAYS = 4745
 
+# In NEX-GDDP-CMIP6, the 'historical' run covers ~1950-2014 and every SSP
+# scenario (ssp126/245/585) covers 2015 onward. A request for an SSP scenario
+# spanning the boundary must pull the pre-2015 portion from 'historical', or
+# those years come back empty.
+NEX_GDDP_HISTORICAL_END = date(2014, 12, 31)
+NEX_GDDP_SSP_START      = date(2015, 1, 1)
+
 def _variables_to_bands(variables) -> List[str]:
     """Map requested ClimateVariable enums (or plain strings) to NEX-GDDP band names."""
     bands: List[str] = []
@@ -134,22 +141,26 @@ class DownloadData(models.DataDownloadBase):
         point = ee.Geometry.Point([lon, lat])
 
         chunks: List[pd.DataFrame] = []
-        current = self.date_from_utc
-        while current <= self.date_to_utc:
-            chunk_end = min(
-                current + timedelta(days=NEX_GDDP_CHUNK_DAYS - 1),
-                self.date_to_utc,
-            )
-            try:
-                df_chunk = self._fetch_chunk(point, current, chunk_end, bands)
-                if not df_chunk.empty:
-                    chunks.append(df_chunk)
-            except Exception as exc:  
-                logger.error(
-                    f"NEX-GDDP {self.model}/{self.scenario} chunk "
-                    f"{current}->{chunk_end} failed: {exc}"
+        # Split the request across the historical/SSP boundary so pre-2015 years
+        # are pulled from the 'historical' run rather than coming back empty.
+        for seg_scenario, seg_start, seg_end in self._scenario_segments():
+            current = seg_start
+            while current <= seg_end:
+                chunk_end = min(
+                    current + timedelta(days=NEX_GDDP_CHUNK_DAYS - 1),
+                    seg_end,
                 )
-            current = chunk_end + timedelta(days=1)
+                try:
+                    df_chunk = self._fetch_chunk(point, current, chunk_end, bands,
+                                                 seg_scenario)
+                    if not df_chunk.empty:
+                        chunks.append(df_chunk)
+                except Exception as exc:
+                    logger.error(
+                        f"NEX-GDDP {self.model}/{seg_scenario} chunk "
+                        f"{current}->{chunk_end} failed: {exc}"
+                    )
+                current = chunk_end + timedelta(days=1)
 
         if not chunks:
             return pd.DataFrame()
@@ -165,16 +176,39 @@ class DownloadData(models.DataDownloadBase):
                 df[tcol] = df[tcol].astype(float) - 273.15
         return df
 
+    def _scenario_segments(self) -> List[Tuple[str, date, date]]:
+        """Split [date_from, date_to] into (scenario, start, end) segments that
+        honour the NEX-GDDP historical/SSP boundary.
+
+        - scenario 'historical': one segment over the whole range.
+        - an SSP scenario: the pre-2015 portion is served from 'historical'
+          and the 2015+ portion from the SSP, so a range crossing the boundary
+          returns continuous data instead of dropping the historical years.
+        """
+        if self.scenario == 'historical':
+            return [('historical', self.date_from_utc, self.date_to_utc)]
+        segments: List[Tuple[str, date, date]] = []
+        if self.date_from_utc <= NEX_GDDP_HISTORICAL_END:
+            segments.append(('historical', self.date_from_utc,
+                             min(self.date_to_utc, NEX_GDDP_HISTORICAL_END)))
+        if self.date_to_utc >= NEX_GDDP_SSP_START:
+            segments.append((self.scenario,
+                             max(self.date_from_utc, NEX_GDDP_SSP_START),
+                             self.date_to_utc))
+        return segments
+
     def _fetch_chunk(self, point: "ee.Geometry", from_date: date,
-                     to_date: date, bands: List[str]) -> pd.DataFrame:
-        """Fetch one date-range chunk and return a per-day DataFrame."""
+                     to_date: date, bands: List[str],
+                     scenario: Optional[str] = None) -> pd.DataFrame:
+        """Fetch one date-range chunk for a given scenario; per-day DataFrame."""
+        scenario = scenario or self.scenario
         start = ee.Date(from_date.strftime("%Y-%m-%d"))
         end = ee.Date(to_date.strftime("%Y-%m-%d")).advance(1, "day")
 
         col = (
             ee.ImageCollection(NEX_GDDP_COLLECTION)
             .filter(ee.Filter.eq("model", self.model))
-            .filter(ee.Filter.eq("scenario", self.scenario))
+            .filter(ee.Filter.eq("scenario", scenario))
             .filterDate(start, end)
             .filterBounds(point)
             .select(bands)


### PR DESCRIPTION
﻿## Summary
Promotes #132 from staging to main: fixes the NEX-GDDP historical/SSP boundary split (so requests spanning 2014/2015 return the full period instead of only 2015+), parallelizes the compare_datasets NEX-GDDP ensemble fetch, and adds the UTF-8 console fix. Resolves the reopened claims on #72.
