### PR TITLE
Release: fix mislabeled hazards.py CLI example (#79)

### DIFF
--- a/climate_tookit/calculate_hazards/hazards.py
+++ b/climate_tookit/calculate_hazards/hazards.py
@@ -1144,7 +1144,7 @@ if __name__ == "__main__":
                 f.write(json.dumps(result, indent=2, default=str))
 
 # Auto-detect season (no season flag supplied -- always uses chirps+chirts internally):
-# python -m climate_tookit.calculate_hazards.hazards maize --location="-1.286,36.817" --date-from 2016-01-01 --date-to 2016-12-31 --season-start 2016-03-01 --season-end 2016-06-30
+# python -m climate_tookit.calculate_hazards.hazards maize --location="-1.286,36.817" --date-from 2016-01-01 --date-to 2016-12-31
 
 # Fixed single season:
 # python -m climate_tookit.calculate_hazards.hazards maize --location="-1.286,36.817" --date-from 2018-01-01 --date-to 2022-12-31 --fixed-season "03-01:06-30" --source era_5


### PR DESCRIPTION
﻿## Summary
Promotes #136 from staging to main: fixes the mislabeled "Auto-detect season" CLI example in hazards.py (it used --season-start/--season-end, duplicating the explicit-season example). Addresses the CLI-comment part of #79.
